### PR TITLE
Gem version updates and dealt with some uninitialized variables.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,40 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
-      public_suffix (>= 2.0.2, < 5.0)
-    builder (3.2.3)
+    addressable (2.4.0)
+    builder (3.2.4)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    faraday (0.17.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    git (1.2.9.1)
-    github_api (0.18.2)
-      addressable (~> 2.4)
+    git (1.5.0)
+    github_api (0.16.0)
+      addressable (~> 2.4.0)
       descendants_tracker (~> 0.0.4)
-      faraday (~> 0.8)
-      hashie (~> 3.5, >= 3.5.2)
+      faraday (~> 0.8, < 0.10)
+      hashie (>= 3.4)
+      mime-types (>= 1.16, < 3.0)
       oauth2 (~> 1.0)
-    hashie (3.6.0)
-    highline (1.7.10)
-    jeweler (2.0.1)
+    hashie (4.0.0)
+    highline (2.0.3)
+    jeweler (2.3.9)
       builder
-      bundler (>= 1.0)
+      bundler
       git (>= 1.2.5)
-      github_api
+      github_api (~> 0.16.0)
       highline (>= 1.6.15)
       nokogiri (>= 1.5.10)
+      psych
       rake
       rdoc
-    json (1.8.6)
+      semver2
     jwt (2.2.1)
+    mime-types (2.99.3)
     mini_portile2 (2.4.0)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nokogiri (1.10.7)
-      mini_portile2 (~> 2.4.0)
-    nokogiri (1.10.7-x86-mingw32)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.2)
       faraday (>= 0.8, < 2.0)
@@ -42,21 +42,22 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    public_suffix (4.0.1)
+    power_assert (1.1.5)
+    psych (3.1.0)
     rack (2.0.7)
-    rake (10.4.2)
-    rdoc (4.2.2)
-      json (~> 1.4)
-    test-unit (2.2.0)
+    rake (13.0.1)
+    rdoc (6.2.0)
+    semver2 (3.4.2)
+    test-unit (3.3.4)
+      power_assert
     thread_safe (0.3.6)
 
 PLATFORMS
   ruby
-  x86-mingw32
 
 DEPENDENCIES
   jeweler
   test-unit
 
 BUNDLED WITH
-   1.16.1
+   1.17.2

--- a/lib/glutton_ratelimit/averaged_throttle.rb
+++ b/lib/glutton_ratelimit/averaged_throttle.rb
@@ -1,9 +1,12 @@
 module GluttonRatelimit
-  
   class AveragedThrottle < ParentLimiter
+    def initialize executions, time_period
+      super(executions, time_period)
+      @tokens = nil
+    end
     
     def reset_bucket
-      @before_previous_execution = Time.now if @before_previous_execution.nil?
+      @before_previous_execution ||= Time.now 
       @oldest_timestamp = Time.now
       @tokens = @executions
       @total_task_time = 0
@@ -19,7 +22,7 @@ module GluttonRatelimit
     
     def wait
       reset_bucket if @tokens.nil?
-      
+
       now = Time.now
       delta_since_previous = now - @before_previous_execution
       @total_task_time += delta_since_previous
@@ -36,9 +39,7 @@ module GluttonRatelimit
       @tokens -= 1
       @before_previous_execution = Time.now
     end
-    
   end
-
 end
 
 

--- a/lib/glutton_ratelimit/bursty_ring_buffer.rb
+++ b/lib/glutton_ratelimit/bursty_ring_buffer.rb
@@ -3,7 +3,7 @@ module GluttonRatelimit
   class BurstyRingBuffer < ParentLimiter
     
     def oldest_timestamp
-      @timestamps = Array.new executions, (Time.now - @time_period) if @timestamps.nil?
+      @timestamps ||= Array.new executions, (Time.now - @time_period) 
       @timestamps[0]
     end
     

--- a/lib/glutton_ratelimit/bursty_token_bucket.rb
+++ b/lib/glutton_ratelimit/bursty_token_bucket.rb
@@ -1,6 +1,10 @@
 module GluttonRatelimit
   
   class BurstyTokenBucket < ParentLimiter
+    def initialize executions, time_period
+      super(executions, time_period)
+      @tokens = nil
+    end
     
     def reset_bucket
       @oldest_timestamp = Time.now


### PR DESCRIPTION
The `Gemfile.lock` was removed and all gems were bumped to their latest versions. As a result some of the tests were showing warnings about uninitialized variables. These issues were then fixed.